### PR TITLE
refactor: Set side of ding to CLIENT for Forge and Minecraft

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -15,12 +15,12 @@ description="Adds a blurry background when viewing GUIs"
 [[dependencies.blur]]
     modId="forge"
     mandatory=true
-    versionRange="[28.1.0,)"
+    versionRange="[36.1.0)"
     ordering="NONE"
-    side="BOTH"
-[[dependencies.firstaid]]
+    side="CLIENT"
+[[dependencies.blur]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.14.4,1.16)"
+    versionRange="[1.16.5)"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"


### PR DESCRIPTION
A small change in the [[dependencies.blur]] declaration which reflects the actual side of the mod when used. This will help ServerPackCreator identify the sideness in future upates.

For reference: Griefed/ServerPackCreator#70

Please let me know if you have any issues with this.

Cheers,
Griefed